### PR TITLE
Change dependency for fakeweb gem

### DIFF
--- a/global_collect.gemspec
+++ b/global_collect.gemspec
@@ -25,9 +25,9 @@ extensibility in mind.
   s.add_dependency 'httparty'
   s.add_dependency 'builder'
   s.add_dependency 'fixed_width'
-  s.add_dependency 'fakeweb'
   s.add_dependency 'crack'
 
+  s.add_development_dependency 'fakeweb'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'geminabox'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'global_collect'
 # initialiaze the logger and silence it for the tests
 GlobalCollect.wire_logger.level = 4
 
-require 'global_collect/test_helper'
+require File.join(File.dirname(__FILE__), 'test_helper')
 
 FakeWeb.allow_net_connect = false
 def wire_up_response(success, action, version)

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -2,7 +2,7 @@
 require 'fakeweb'
 
 def support_path(filename)
-  File.expand_path File.join(File.dirname(__FILE__), '..', '..', 'spec', 'support', filename)
+  File.expand_path File.join(File.dirname(__FILE__), 'support', filename)
 end
 
 def read_support_file(filename)


### PR DESCRIPTION
We'd like to avoid require fakeweb on production. Because the gam overrides `Net::HTTP` classes.
This PR changes the dependency.